### PR TITLE
Add support for :equality keyword

### DIFF
--- a/pyperplan/pddl/pddl.py
+++ b/pyperplan/pddl/pddl.py
@@ -79,6 +79,13 @@ class Effect:
         self.addlist = set()
         self.dellist = set()
 
+    def __repr__(self):
+        return ("add=[" + ", ".join(map(lambda e: str(e), self.addlist)) + "], " +
+            "del=[" + ", ".join(map(lambda e: str(e), self.dellist)) + "]"
+        )
+
+    __str__ = __repr__
+
 
 class Action:
     def __init__(self, name, signature, precondition, effect):


### PR DESCRIPTION
Here is the pull request for the :equality keyword. This was more difficult since Pyperplan doesn't support negative preconditions; i.e., differently from effects where each action has an add and del list, preconditions are simply a list of Predicates() so it wouldn't be that easy to accommodate "native" negative preconditions such as ```(not (= ?x ?x)))```.

Therefore, I did the following "hacky" trick. When :equality is specified, two new predicates are created: "=" and "not=". Then, each instance of ```(not (= ?x ?x))``` in preconditions is translated into ```(not= ?x ?x)```, thus removing the negation. Checks that raise errors for the use of "=" and "not=" in effects, and the use of ```(not <predicate>)``` in non-equality preconditions are done. Constructs like ```(not (not (?x ?x)))``` and ```(not (not= ?x ?x))``` that are semantically right are refused, and constructs like ```(not= ?x ?x)``` are accepted.

On the other hand, the initial situation of a problem is extended with denotations for "=" and "not=". That is, the initial situation is extended with atoms ```(= o o)``` for each object o, and with atoms ```(not= o1 o2)``` for each pair of different objects o1 and o2.

I have tried to adhere to the style.
