### PR TITLE
fix string representation for objects in problem struct

### DIFF
--- a/pyperplan/pddl/pddl.py
+++ b/pyperplan/pddl/pddl.py
@@ -148,7 +148,7 @@ class Problem:
             % (
                 self.name,
                 self.domain.name,
-                [self.objects[o].name for o in self.objects],
+                sorted(self.objects),
                 [str(p) for p in self.initial_state],
                 [str(p) for p in self.goal],
             )


### PR DESCRIPTION
Closes #18

Example of `print("Problem:", problem)` before this change:

```
Problem: < Problem definition: logistics-4-0 Domain: logistics Objects: ['airplane', 'airport', 'airport', 'location', 'location', 'city', 'city', 'truck', 'truck', 'package', 'package', 'package', 'package', 'package', 'package'] Initial State: ["at[('apn1', airplane), ('apt2', airport)]", "at[('tru1', truck), ('pos1', location)]", "at[('obj11', package), ('pos1', location)]", "at[('obj12', package), ('pos1', location)]", "at[('obj13', package), ('pos1', location)]", "at[('tru2', truck), ('pos2', location)]", "at[('obj21', package), ('pos2', location)]", "at[('obj22', package), ('pos2', location)]", "at[('obj23', package), ('pos2', location)]", "in-city[('pos1', location), ('cit1', city)]", "in-city[('apt1', airport), ('cit1', city)]", "in-city[('pos2', location), ('cit2', city)]", "in-city[('apt2', airport), ('cit2', city)]"] Goal State : ["at[('obj11', (physobj,)), ('apt1', (place,))]", "at[('obj23', (physobj,)), ('pos1', (place,))]", "at[('obj13', (physobj,)), ('apt1', (place,))]", "at[('obj21', (physobj,)), ('pos1', (place,))]"] >
```

After this change:

```
Problem: < Problem definition: logistics-4-0 Domain: logistics Objects: ['apn1', 'apt1', 'apt2', 'cit1', 'cit2', 'obj11', 'obj12', 'obj13', 'obj21', 'obj22', 'obj23', 'pos1', 'pos2', 'tru1', 'tru2'] Initial State: ["at[('apn1', airplane), ('apt2', airport)]", "at[('tru1', truck), ('pos1', location)]", "at[('obj11', package), ('pos1', location)]", "at[('obj12', package), ('pos1', location)]", "at[('obj13', package), ('pos1', location)]", "at[('tru2', truck), ('pos2', location)]", "at[('obj21', package), ('pos2', location)]", "at[('obj22', package), ('pos2', location)]", "at[('obj23', package), ('pos2', location)]", "in-city[('pos1', location), ('cit1', city)]", "in-city[('apt1', airport), ('cit1', city)]", "in-city[('pos2', location), ('cit2', city)]", "in-city[('apt2', airport), ('cit2', city)]"] Goal State : ["at[('obj11', (physobj,)), ('apt1', (place,))]", "at[('obj23', (physobj,)), ('pos1', (place,))]", "at[('obj13', (physobj,)), ('apt1', (place,))]", "at[('obj21', (physobj,)), ('pos1', (place,))]"] >
```