### PR TITLE
Support Python 3.10-3.14 and PyPy; drive CI with uv

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,31 +18,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-        python-version: [3.8, 3.9, '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.10', 'pypy3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
 
     - name: Show environment
       run: |
-        python --version
-        python3 -c "import multiprocessing as m; print('CPUs:', m.cpu_count())"
+        uv run --python ${{ matrix.python-version }} python --version
+        uv run --python ${{ matrix.python-version }} python -c "import multiprocessing as m; print('CPUs:', m.cpu_count())"
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get -y install minisat python3-pip tox
+    - name: Install minisat
+      run: sudo apt-get -y install minisat
 
     - name: Check style
       if: matrix.os == 'ubuntu-24.04' && matrix.python-version == '3.14'
       run: |
-        tox -e style
+        uvx ruff@0.15.2 check .
+        uvx ruff@0.15.2 format --check .
 
     - name: Run tests
-      run: |
-        tox -e py,slow
+      run: uv run --python ${{ matrix.python-version }} --group dev pytest --slow pyperplan/tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-24.04, ubuntu-26.04]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.10', 'pypy3.11']
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ input.cnf
 output.txt
 uv.lock
 .tox/
+.venv/
 build/
 dist/
 pyperplan.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Support Python 3.10 to 3.14 and PyPy. Raise the minimum Python version to 3.10.
 * Add a `dev` dependency group and run continuous integration tests with uv.
+* Enable ruff's pyupgrade (`UP`) rules to keep the code on modern Python syntax.
 
 
 # 2.1 (2022-01-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.2 (unreleased)
 
-* Raise minimum Python version to 3.7 and maximum Python version to 3.13 (#28).
+* Support Python 3.10 to 3.14 and PyPy. Raise the minimum Python version to 3.10.
+* Add a `dev` dependency group and run continuous integration tests with uv.
 
 
 # 2.1 (2022-01-17)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ line-length = 88
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 "*/tests/*" = ["F403", "F405", "F811"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pyperplan"
 version = "2.1"
 description = "A lightweight STRIPS planner written in Python."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "GPL-3.0-or-later"
 keywords = ["classical planning", "STRIPS"]
 authors = [{ name = "Jendrik Seipp", email = "jendrik.seipp@liu.se" }]
@@ -14,13 +14,13 @@ classifiers = [
     "Intended Audience :: Education",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Scientific/Engineering",
 ]
 dependencies = []
@@ -38,8 +38,17 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["pyperplan*"]
 
+[dependency-groups]
+dev = [
+    "pytest",
+    "ruff==0.15.2",
+]
+
 [tool.ruff]
 line-length = 88
+# Target the minimum supported Python version so lints and autofixes only
+# suggest syntax that runs on all supported interpreters.
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]


### PR DESCRIPTION
Raise the minimum Python version to 3.10 (dropping 3.8 and 3.9) and
advertise PyPy support via trove classifiers. Add a uv 'dev' dependency
group for pytest and ruff, and run the CI test and style jobs through uv
so it can provision both CPython 3.10-3.14 and PyPy interpreters.

Set ruff's target-version to py310. Enabling pyupgrade against py310
reports no changes, so the version bump does not unlock cleaner syntax or
better data structures in the current (already-modernized) code.